### PR TITLE
Change trigger inputs to follow Rack voltage standards

### DIFF
--- a/src/Kickall.cpp
+++ b/src/Kickall.cpp
@@ -81,7 +81,7 @@ struct Kickall : Module {
 
 	void process(const ProcessArgs& args) override {
 		// TODO: check values
-		const bool risingEdgeGate = gateTrigger.process(inputs[TRIGG_INPUT].getVoltage() / 2.0f);
+		const bool risingEdgeGate = gateTrigger.process(inputs[TRIGG_INPUT].getVoltage() / 2.0f, 0.1, 2.0);
 		const bool buttonTriggered = buttonTrigger.process(params[TRIGG_BUTTON_PARAM].getValue());
 		// can be triggered by either rising edge on trigger in, or a button press
 		if (risingEdgeGate || buttonTriggered) {

--- a/src/Muxlicer.cpp
+++ b/src/Muxlicer.cpp
@@ -1120,7 +1120,7 @@ struct Mex : Module {
 					// gate in will convert non-gate signals to gates (via schmitt trigger)
 					// if input is present
 					if (inputs[GATE_IN_INPUT].isConnected()) {
-						gateInTrigger.process(inputs[GATE_IN_INPUT].getVoltage());
+						gateInTrigger.process(inputs[GATE_IN_INPUT].getVoltage(), 0.1, 2.0);
 						gate = gateInTrigger.isHigh();
 					}
 					// otherwise the main Muxlicer output clock (including divisions/multiplications)

--- a/src/Rampage.cpp
+++ b/src/Rampage.cpp
@@ -220,7 +220,7 @@ struct Rampage : Module {
 			for (int c = 0; c < channels[part]; c += 4) {
 
 				// process SchmittTriggers
-				float_4 trig_mask = trigger_4[part][c / 4].process(in_trig[c / 4] / 2.0);
+				float_4 trig_mask = trigger_4[part][c / 4].process(in_trig[c / 4] / 2.0, 0.1, 2.0);
 				gate[part][c / 4] = ifelse(trig_mask, float_4::mask(), gate[part][c / 4]);
 				in[c / 4] = ifelse(gate[part][c / 4], 10.0f, in[c / 4]);
 


### PR DESCRIPTION
Certain modules didn't follow VCV's recommended voltage standards for detecting triggers. Changed them to follow them.

Standards: <https://vcvrack.com/manual/VoltageStandards#Triggers-and-Gates>

This was preventing the monome module Ansible from triggering these modules. <https://github.com/Dewb/monome-rack/issues/187>

I declare this tiny patch to be public domain, if that helps integrate it or reimplement it to avoid copyright issues.